### PR TITLE
fix: model_path can be None

### DIFF
--- a/retrieval.py
+++ b/retrieval.py
@@ -32,7 +32,7 @@ parser.add_argument("--lr_pfc_weight", type=float, default=5.0, help="The weight
 parser.add_argument("--input_size", default=224, type=int, help="The size of the input images for the model.")
 parser.add_argument("--gradient_acc", default=1, type=int, help="The number of times gradients are accumulated before updating the model's parameters.")
 parser.add_argument("--model_name", default="ViT-B/16", help="The name of the pre-trained model to use for feature extraction.")
-parser.add_argument("--model_path", default="ViT-B/16", help="The name of the pre-trained model to use for feature extraction.")
+parser.add_argument("--model_path", default=None, help="The name of the pre-trained model to use for feature extraction.")
 
 parser.add_argument("--margin_loss_m1", type=float, default=1.0, help="The margin parameter (m1) for the margin loss function.")
 parser.add_argument("--margin_loss_m2", type=float, default=0.3, help="The margin parameter (m1) for the margin loss function.")

--- a/unicom/model.py
+++ b/unicom/model.py
@@ -80,16 +80,28 @@ def _download(url: str, root: str):
 
 # copy from https://github.com/openai/CLIP/blob/main/clip/clip.py#L94
 def load(path: str, name: str, device: str = "cpu", download_root: str = None):
+    if path is None:
+        path = name
+    elif name is None:
+        assert path in _MODELS
+        name = path
+
     if path in _MODELS:
         model_path = _download(
             _MODELS[path], download_root or os.path.expanduser("~/.cache/unicom"))
+        with open(model_path, 'rb') as opened_file:
+            state_dict = torch.load(opened_file, map_location="cpu")
+        print(f"Loaded model {path} from unicom!")
+        
     elif os.path.isfile(path):
         model_path = path
+        with open(model_path, 'rb') as opened_file:
+            state_dict = torch.load(opened_file, map_location="cpu")['model_state_dict']
+        print(f"Loaded model from {path}!")
     else:
         raise RuntimeError(
             f"Model {path} not found; available models = {available_models()}")
-    with open(model_path, 'rb') as opened_file:
-        state_dict = torch.load(opened_file, map_location="cpu")['model_state_dict']
+    
 
     model, transform = load_model_and_transform(name)
 


### PR DESCRIPTION
`--model_path` : pre-trained model path (if it's `None`, it will bring a model from unicom)
`--model_name` : valid model architecture. among ViT-B/16, ViT-B/32, ...
